### PR TITLE
Expand str and padString types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,14 @@ export function substring(str, begin, end) {
 }
 
 export function limit(str, limit = 16, padString = "#", padPosition = "right") {
+    if( ["string", "undefined"].indexOf( typeof str ) === -1  ){
+        str = str.toString();
+    }
+    
+    if( typeof padString !== 'string' ){
+        padString = padString.toString();
+    }
+    
     if (typeof str !== "string" || typeof limit !== "number") {
         throw new Error("Invalid arguments specified");
     }


### PR DESCRIPTION
I want to use limit function to limit my numbers. 2 --> 02. 6 --> 06. 12 --> 12.
before this pull request, this code have an error:
`limit(6, 2, 0, 'left'); // 06 `
becouse of str and padString types (that is not string).
current solution is:
`limit( (6).toString(), 2, (0).toString(), 'left' ) // 06`
but it is difficult to use anywhere.
i do not fix anythings, i just make limit function more compassionate.
