### PR TITLE
Fix empty string substring bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,10 @@ export function substring(str, begin = 0, end) {
     end = 0;
   }
 
-  return str
-    .match(astralRange)
-    .slice(begin, end)
-    .join('');
+  const match = str.match(astralRange);
+  if (!match) return '';
+
+  return match.slice(begin, end).join('');
 }
 
 /**
@@ -104,10 +104,10 @@ export function substr(str, begin = 0, len) {
     end = len >= 0 ? len + begin : begin;
   }
 
-  return str
-    .match(astralRange)
-    .slice(begin, end)
-    .join('');
+  const match = str.match(astralRange);
+  if (!match) return '';
+
+  return match.slice(begin, end).join('');
 }
 
 /**

--- a/test/substr.test.js
+++ b/test/substr.test.js
@@ -17,6 +17,10 @@ describe('Substr', () => {
     assert.strictEqual(substr(emojiString, 7, 7), '👍🏽 are 🍆');
   });
 
+  it('Substrs empty text correctly', () => {
+    assert.strictEqual(substr('', 0, 11), '');
+  });
+
   it('Substrs if arguments are unspecified', () => {
     assert.strictEqual(substr(string, 10), string.substr(10));
     assert.strictEqual(substr(string, 120), string.substr(120));

--- a/test/substring.test.js
+++ b/test/substring.test.js
@@ -20,6 +20,10 @@ describe('Substring', () => {
     assert.strictEqual(substring(emojiString, 7, 14), '👍🏽 are 🍆');
   });
 
+  it('Substrings empty text correctly', () => {
+    assert.strictEqual(substring('', 0, 11), '');
+  });
+
   it('Substrings if arguments are unspecified', () => {
     assert.strictEqual(substring(string, 10), string.substring(10));
     assert.strictEqual(substring(string), string);


### PR DESCRIPTION
```js
stringz.substring('', 0 1) // throws an undefined error
stringz.substr('', 0 1) // throws an undefined error
```

fixes #28

