### PR TITLE
Allow multi-character padding

### DIFF
--- a/src/__tests__/limit.test.ts
+++ b/src/__tests__/limit.test.ts
@@ -51,6 +51,13 @@ describe('Limit String Length', () => {
     );
   });
 
+  it('Uses custom oversized multi-character padding if provided', () => {
+    assert.equal(
+      limit("Life's like a box of chocolates.", 35, '12345'),
+      "Life's like a box of chocolates.123"
+    );
+  });
+
   it('Applies padding to correct position if specified', () => {
     assert.equal(
       limit("Life's like a box of chocolates.", 35, '/', 'left'),
@@ -62,6 +69,13 @@ describe('Limit String Length', () => {
     assert.equal(
       limit("Life's like a box of chocolates.", 35, '+-', 'left'),
       "+-+Life's like a box of chocolates."
+    );
+  });
+
+  it('Applies oversized multi-character padding to correct position if specified', () => {
+    assert.equal(
+      limit("Life's like a box of chocolates.", 35, '12345', 'left'),
+      "123Life's like a box of chocolates."
     );
   });
 

--- a/src/__tests__/limit.test.ts
+++ b/src/__tests__/limit.test.ts
@@ -44,10 +44,24 @@ describe('Limit String Length', () => {
     );
   });
 
+  it('Uses custom multi-character padding if provided', () => {
+    assert.equal(
+      limit("Life's like a box of chocolates.", 35, '+-'),
+      "Life's like a box of chocolates.+-+"
+    );
+  });
+
   it('Applies padding to correct position if specified', () => {
     assert.equal(
       limit("Life's like a box of chocolates.", 35, '/', 'left'),
       "///Life's like a box of chocolates."
+    );
+  });
+
+  it('Applies multi-character padding to correct position if specified', () => {
+    assert.equal(
+      limit("Life's like a box of chocolates.", 35, '+-', 'left'),
+      "+-+Life's like a box of chocolates."
     );
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,10 @@ export function limit(
   if (strLength > limit) {
     return substring(str, 0, limit);
   } else if (strLength < limit) {
-    const padRepeats = padString.repeat(limit - strLength);
+    const padLength = limit - strLength;
+    const padRepeats = padString
+      .repeat(Math.ceil(padLength / padString.length))
+      .slice(0, padLength);
     return padPosition === 'left' ? padRepeats + str : str + padRepeats;
   }
 


### PR DESCRIPTION
Padding a string using the `limit` function would only work when the `padString` would be a single character. This PR fixes the padding code so that it also works for multiple character pad strings.